### PR TITLE
[PEDSP-10823] Fix error on key_select

### DIFF
--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -36,6 +36,7 @@
     key_select/1,
     key_select/2,
     key_select/4,
+    key_select/5,
     key_remove/0,
     key_remove/1,
     key_remove/3,
@@ -78,7 +79,7 @@
     key_generation/3,
     key_put/4,
     key_remove/3,
-    key_select/4,
+    key_select/5,
     nif_node_random/0,
     nif_node_names/0,
     nif_node_get/1,
@@ -252,11 +253,14 @@ key_select(Lst) ->
 key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
+key_select(Namespace, Set, Key, Lst) ->
+  key_select(Namespace, Set, Key, Lst, false).
+
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()]) ->
+-spec key_select(string(), string(), string(), [string()], boolean()) ->
     {ok, [{string(), term()}]} | {error, string()}.
-key_select(Namespace, Set, Key, Lst) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst)
+key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
+    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
     not_loaded(?LINE).
 

--- a/src/aspike_srv.erl
+++ b/src/aspike_srv.erl
@@ -77,6 +77,7 @@
     key_select/1,
     key_select/2,
     key_select/4,
+    key_select/5,
     key_remove/0,
     key_remove/1,
     key_remove/3,
@@ -251,13 +252,16 @@ key_select(Lst) ->
 key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
+key_select(Namespace, Set, Key, Lst) ->
+    key_select(Namespace, Set, Key, Lst, false).
+
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()]) ->
+-spec key_select(string(), string(), string(), [string()], boolean()) ->
     {ok, [{string(), term()}]} | {error, string()}.
-key_select(Namespace, Set, Key, Lst) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst)
+key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
+    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
-    command({key_select, Namespace, Set, Key, Lst}).
+    command({key_select, Namespace, Set, Key, Lst, HandleStringAsBytes}).
 
 key_get() ->
     key_get(?DEFAULT_KEY).

--- a/src/aspike_srv_worker.erl
+++ b/src/aspike_srv_worker.erl
@@ -78,6 +78,7 @@
     key_select/1,
     key_select/2,
     key_select/4,
+    key_select/5,
     key_remove/0,
     key_remove/1,
     key_remove/3,
@@ -271,13 +272,16 @@ key_select(Lst) ->
 key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
+key_select(Namespace, Set, Key, Lst) ->
+    key_select(Namespace, Set, Key, Lst, false).
+
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()]) ->
+-spec key_select(string(), string(), string(), [string()], boolean()) ->
     {ok, [{string(), term()}]} | {error, string()}.
-key_select(Namespace, Set, Key, Lst) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst)
+key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
+    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
-    command({key_select, Namespace, Set, Key, Lst}).
+    command({key_select, Namespace, Set, Key, Lst, HandleStringAsBytes}).
 
 key_get() ->
     key_get(?DEFAULT_KEY).


### PR DESCRIPTION
- introduce a new parameter `handle_string_as_bytes` (default value `false`) to dump_records and form_value_out
- use as_record_get instead of as_bin_get_value

With the test data below,
```
aql> select * from global-store.test_key;
+-----+-------+-------+--------------------+
| PK  | col_1 | col_2 | col_3              |
+-----+-------+-------+--------------------+
| "2" | 200   | false | "another string 2" |
| "1" | 100   | true  | "another string"   |
+-----+-------+-------+--------------------+
2 rows in set (0.010 secs)
```

Previously, key_select couldn't get values at all.

```
5> aspike_nif:key_select("global-store", "test_key", "1", ["col_1", "col_2", "col_3"]).
{ok,[{"col_3",<<>>},{"col_2","true"},{"col_1",100}]}
```

By this change, it brings values well.
```
5> aspike_nif:key_select("global-store", "test_key", "1", ["col_1", "col_2", "col_3"]).
{ok,[{"col_3",<<"another string">>},
     {"col_2","true"},
     {"col_1",100}]}
6> aspike_nif:key_select("global-store", "test_key", "1", ["col_1", "col_2", "col_3"], false).
{ok,[{"col_3",<<"another string">>},
     {"col_2","true"},
     {"col_1",100}]}
7> aspike_nif:key_select("global-store", "test_key", "1", ["col_1", "col_2", "col_3"], true).
{ok,[{"col_3",<<>>},{"col_2","true"},{"col_1",100}]}
```