### PR TITLE
[PEDSP-10865] handle_string_as_bytes now has true by default, fix badarg issue in key_select

### DIFF
--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -254,13 +254,13 @@ key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
 key_select(Namespace, Set, Key, Lst) ->
-  key_select(Namespace, Set, Key, Lst, false).
+  key_select(Namespace, Set, Key, Lst, true).
 
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()], boolean()) ->
-    {ok, [{string(), term()}]} | {error, string()}.
+-spec key_select(binary(), binary(), binary(), [binary()], boolean()) ->
+    {ok, [{binary(), term()}]} | {error, binary()}.
 key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
+    is_binary(Namespace), is_binary(Set), is_binary(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
     not_loaded(?LINE).
 

--- a/src/aspike_srv.erl
+++ b/src/aspike_srv.erl
@@ -253,13 +253,13 @@ key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
 key_select(Namespace, Set, Key, Lst) ->
-    key_select(Namespace, Set, Key, Lst, false).
+    key_select(Namespace, Set, Key, Lst, true).
 
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()], boolean()) ->
-    {ok, [{string(), term()}]} | {error, string()}.
+-spec key_select(binary(), binary(), binary(), [binary()], boolean()) ->
+    {ok, [{binary(), term()}]} | {error, binary()}.
 key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
+    is_binary(Namespace), is_binary(Set), is_binary(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
     command({key_select, Namespace, Set, Key, Lst, HandleStringAsBytes}).
 

--- a/src/aspike_srv_worker.erl
+++ b/src/aspike_srv_worker.erl
@@ -273,7 +273,7 @@ key_select(Key, Lst) ->
     key_select(?DEFAULT_NAMESPACE, ?DEFAULT_SET, Key, Lst).
 
 key_select(Namespace, Set, Key, Lst) ->
-    key_select(Namespace, Set, Key, Lst, false).
+    key_select(Namespace, Set, Key, Lst, true).
 
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
 -spec key_select(binary(), binary(), binary(), [binary()], boolean()) ->

--- a/src/aspike_srv_worker.erl
+++ b/src/aspike_srv_worker.erl
@@ -276,10 +276,10 @@ key_select(Namespace, Set, Key, Lst) ->
     key_select(Namespace, Set, Key, Lst, false).
 
 % Gets value of Bin for Key in Namespace Set; here Lst is a list of [Bin].
--spec key_select(string(), string(), string(), [string()], boolean()) ->
-    {ok, [{string(), term()}]} | {error, string()}.
+-spec key_select(binary(), binary(), binary(), [binary()], boolean()) ->
+    {ok, [{binary(), term()}]} | {error, binary()}.
 key_select(Namespace, Set, Key, Lst, HandleStringAsBytes) when
-    is_list(Namespace), is_list(Set), is_list(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
+    is_binary(Namespace), is_binary(Set), is_binary(Key), is_list(Lst), is_boolean(HandleStringAsBytes)
 ->
     command({key_select, Namespace, Set, Key, Lst, HandleStringAsBytes}).
 


### PR DESCRIPTION
  - badarg error happens because type of arguments' value are binary while aspike_nif.cpp key_select handles them as string type.
  - format_value_out is used by several legacy functions
    - handle_string_as_byte, recently intoduced, has false as default value. but this should be set to true to honor legacy functions which have no idea about handle_string_as_byte.

  Issue reproduced in iex
  ```
  iex(5)> :aspike_nif.key_select(<<"global-store">>, <<"test_key">>, <<"1">>, [<<"col_1">>, <<"col_2">>])
  ** (ArgumentError) argument error
      :aspike_nif.key_select("global-store", "test_key", "1", ["col_1", "col_2"])
      iex:4: (file)
  ```

  And fix resolve the issue
  ```
  iex(5)> :aspike_nif.key_select(<<"global-store">>, <<"test_key">>, <<"1">>, [<<"col_1">>, <<"col_2">>])
  {:ok, [{~c"col_1", ""}, {~c"col_2", ""}]}

  iex(6)> :aspike_nif.key_select(<<"global-store">>, <<"test_key">>, <<"1">>, [<<"col_1">>, <<"col_2">>], true)
  {:ok, [{~c"col_1", ""}, {~c"col_2", ""}]}

  iex(7)> :aspike_nif.key_select(<<"global-store">>, <<"test_key">>, <<"1">>, [<<"col_1">>, <<"col_2">>], false)
  {:ok, [{~c"col_1", "string value 1"}, {~c"col_2", "string value 2"}]}
  ```

