### PR TITLE
[ASPW-289] aspike-client to keep trying be connected to aerospike cluster on first connect

### DIFF
--- a/c_src/nif/Makefile
+++ b/c_src/nif/Makefile
@@ -41,7 +41,7 @@ CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
 LDLIBS += $(AERO_BASE)/lib/libaerospike.a
 LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei 
-LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz  -lstdc++
+LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz -lstdc++ -lyaml
 LDFLAGS += -shared
 
 # Verbosity.

--- a/c_src/nif/Makefile
+++ b/c_src/nif/Makefile
@@ -41,7 +41,7 @@ CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
 LDLIBS += $(AERO_BASE)/lib/libaerospike.a
 LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei 
-LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz -lstdc++ -lyaml
+LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz -lstdc++
 LDFLAGS += -shared
 
 # Verbosity.

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -99,6 +99,13 @@ static ERL_NIF_TERM as_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (!is_aerospike_initialised) {
         as_config config;
         as_config_init(&config);
+
+        // enable constant auto-connection to the cluster no matter what.
+        // as a side-effect, the aerospike_connect() function will report
+        // "connected" even despite a fact the aerospike cluster might be down
+        // currently.
+        config.fail_if_not_connected = false;
+        
         aerospike_init(&as, &config);
         is_aerospike_initialised = true;
     }

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -171,6 +171,19 @@ static ERL_NIF_TERM host_list(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
     return enif_make_tuple2(env, erl_ok, msg);
 }
 
+// -spec connect(User :: string(), Password :: string()) ->
+//     {ok, atom()} |
+//     {error, string()}.
+//
+// Connects to Aerospike cluster with authentication.
+// Unlike basic aerospike_connect(), this function verifies that the cluster
+// has active, responding servers using aerospike_cluster_is_connected().
+//
+// Returns:
+//   {ok, connected} - Successfully connected with active servers available
+//   {ok, no_active_servers_found} - In cluster connected state but no active
+//          aerospike servers are found, thus, the cluster is empty.
+//   {error, ErrorMessage} - Connection failed with error description
 static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     char user[AS_USER_SIZE];
@@ -184,21 +197,31 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
     CHECK_AEROSPIKE_INIT
 
-    ERL_NIF_TERM rc, msg;
     as_config_set_user(&as.config, user, password);
-	as_error err;
 
-    if (aerospike_connect(&as, &err) != AEROSPIKE_OK) {
-        rc = erl_error;
-        msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
+    as_error err;
+    ERL_NIF_TERM response;
+    as_status rc = aerospike_connect(&as, &err);
+    if (rc != AEROSPIKE_OK) {
         is_connected = false;
+        ERL_NIF_TERM error_msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
+        
+        response = enif_make_tuple2(env, erl_error, error_msg);
     } else {
-        rc = erl_ok;
-        msg = enif_make_string(env, "connected", ERL_NIF_UTF8);
         is_connected = true;
+        // Check if we're actually connected to live servers
+        // aerospike_connect() succeeds even with fail_if_not_connected=false
+        // but this checks if cluster has active, responding nodes
+        ERL_NIF_TERM status;
+        if (aerospike_cluster_is_connected(&as)) {
+            status = enif_make_atom(env, "connected");
+        } else {
+            status = enif_make_atom(env, "no_active_servers_found");
+        }
+        response = enif_make_tuple2(env, erl_ok, status);
     }
 
-    return enif_make_tuple2(env, rc, msg);
+    return response;
 }
 
 static ERL_NIF_TERM binary_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/port/Makefile
+++ b/c_src/port/Makefile
@@ -42,7 +42,7 @@ CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 LDLIBS += $(AERO_BASE)/lib/libaerospike.a
 LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei 
 #LDLIBS += -L/usr/local/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz -ldl
-LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -ldl -lstdc++ -lyaml
+LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -ldl -lstdc++
 
 # Verbosity.
 

--- a/c_src/port/Makefile
+++ b/c_src/port/Makefile
@@ -42,7 +42,7 @@ CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 LDLIBS += $(AERO_BASE)/lib/libaerospike.a
 LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei 
 #LDLIBS += -L/usr/local/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -lm -lz -ldl
-LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -ldl  -lstdc++
+LDLIBS += -L/usr/local/lib -L/usr/local/opt/openssl/lib -lev -lssl -lcrypto  -lpthread -lm -lz  -ldl -lstdc++ -lyaml
 
 # Verbosity.
 

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -165,7 +165,7 @@ connect() ->
     connect(?DEFAULT_USER, ?DEFAULT_PSW).
 
 % @doc Create connection using User and PWd credential
--spec connect(string(), string()) -> {ok, string()} | {error, string()}.
+-spec connect(string(), string()) -> {ok, atom()} | {error, string()}.
 connect(_, _) ->
     not_loaded(?LINE).
 


### PR DESCRIPTION
Jira ticket [ASPW-289](https://adgear.atlassian.net/browse/ASPW-289)

It seems like if gateway or delivery instance starts and there is no Aerospike cluster running live and able to accept connection, the gateway or delivery would not get connected after the Aerospike cluster gets back to live. The reason behind this is specific default behavior of the c-client aerospike library (the library), which doesn’t try to re-connect on the very first connection establishment attempt. The very first meaning first established connection. Meaning, once the library gets connected to Aerospike cluster and the cluster goes down again, the library would keep trying to get re-connected back to the cluster forever. But if the library didn’t get connect on first attempt, the library would gave up.

The idea to use [fail_if_not_connected](https://aerospike.com/apidocs/c/d0/d99/structas__config.html#adc88865603d0763edc58bdc4cd26b123) config flag to make the library to continually trying to connect to cluster even on the first connection attempt no matter what. Basically, forever, with 1 second interval between attempts.

[ASPW-289]: https://adgear.atlassian.net/browse/ASPW-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ